### PR TITLE
Exclude repository-only files from distribution archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -31,3 +31,18 @@
 *.gif binary
 *.ico binary
 *.mo binary
+
+# Exclude repository-only files from distribution archives (git archive / Composer dist).
+# These files are needed for development but not at runtime, keeping the published package lean.
+# https://git-scm.com/docs/gitattributes#_export_ignore
+/.editorconfig      export-ignore
+/.gitattributes     export-ignore
+/.github            export-ignore
+/.gitignore         export-ignore
+/.idea              export-ignore
+/CHANGELOG.md       export-ignore
+/composer.lock      export-ignore
+/docs               export-ignore
+/phpcs.xml.dist     export-ignore
+/phpunit.xml.dist   export-ignore
+/tests              export-ignore

--- a/.gitattributes
+++ b/.gitattributes
@@ -40,9 +40,7 @@
 /.github            export-ignore
 /.gitignore         export-ignore
 /.idea              export-ignore
-/CHANGELOG.md       export-ignore
 /composer.lock      export-ignore
-/docs               export-ignore
 /phpcs.xml.dist     export-ignore
 /phpunit.xml.dist   export-ignore
 /tests              export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improved overall documentation
 - Drop support for PHPUnit 8.x
+- Exclude repository-only files from distribution archives [#7](https://github.com/orca-services/cakephp-app-version/issues/7)
 
 ### Dependencies
 - cakephp/cakephp-codesniffer installed in version 4.7.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - Improved overall documentation
 - Drop support for PHPUnit 8.x
-- Exclude repository-only files from distribution archives [#7](https://github.com/orca-services/cakephp-app-version/issues/7)
+- Exclude repository-only files from archives to reduce Composer distribution package size [#7](https://github.com/orca-services/cakephp-app-version/issues/7)
 
 ### Dependencies
 - cakephp/cakephp-codesniffer installed in version 4.7.1


### PR DESCRIPTION
Add support for Git’s .gitattributes export-ignore directive to control which files are included when the package is distributed via Composer.

This allows us to exclude repository-only files (e.g. tests, CI configs, docs, tooling) from distribution archives and keep the package leaner.

Closes #7 